### PR TITLE
'1'のレスポンスは表示しない

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -60,9 +60,9 @@ bot.message(containing: not!("set:")) do |eve|
     system = db.where(:server_id => eve.server.id).get(:system)
     bcdice.setGameByTitle(system)
     bcdice.setMessage(eve.text)
-    hoge, foo = bcdice.dice_command
-    if(hoge != "")
-        eve.respond hoge
+    message, _ = bcdice.dice_command
+    if (message != "" || message != "1")
+        eve.respond message
     end
 end
 


### PR DESCRIPTION
# 問題

このBotは[BCDice](https://github.com/torgtaitai/BCDice)のライブラリをラップしている形になっているけれども、BCDiceの仕様上見落としている点があるので、その修正を送ります。

例えば、ボットシステムとして[DiceBot](https://github.com/torgtaitai/BCDice/blob/f84539cf4afc7bcf37ca8853a649b2dc7735ffc4/src/diceBot/DiceBot.rb )を利用した場合、反応する必要のない内容に関しては「1」というレスポンスが返ってくるような仕様になっています。具体的なコードの内容は下の通り(145行目を参照):

```ruby
    output_msg = '1' if( output_msg.nil? or output_msg.empty? )
    secret_flg ||= false
    
    output_msg = "#{nick_e}: #{output_msg}" if(output_msg != '1')
    
    if( secretMarker )   # 隠しロール
      secret_flg = true if(output_msg != '1')
    end
```

つまり、`output_msg`が「1」である場合、メッセージとして無視する必要になっているが、ラップしている側の場合、これを無視していないため、全部のメッセージに対して反応されてしまうという不具合が出てきてしまっている。なので、`1`を無視するように修正することにしました。

また、hoge, fooという変数はさすがに難がある気がするので、ついでに修正しました。