### PR TITLE
現在のシステムのヘルプをプライベートメッセージで送る

### DIFF
--- a/lib/bcdice_wrapper.rb
+++ b/lib/bcdice_wrapper.rb
@@ -40,6 +40,10 @@ class DiscordBCDice < BCDice
       end
     end
 
+    def getHelpMessage
+      @diceBot.getHelpMessage
+    end
+
     private
     def replace_systemName(system_name)
       system_name.gsub!(/[_|!]/, "")

--- a/main.rb
+++ b/main.rb
@@ -51,6 +51,14 @@ bot.message(with_text: "!systemlist") do |eve|
   eve.user.pm("```#{help_lines_after}```")
 end
 
+bot.message(with_text:"!systemhelp") do |eve|
+  test_get_data = db.first(:server_id => eve.server.id)
+  unless test_get_data.nil?
+    bcdice.setGameByTitle(test_get_data[:system])
+    eve.user.pm("```#{bcdice.getHelpMessage}```")
+  end
+end
+
 # set system event
 bot.message(contains: "set:") do |eve|
   system = (/^set:( *)(.+)/.match(eve.text))[2]


### PR DESCRIPTION
`!systemhelp`で、現在セットされているシステムのヘルプをプライベートメッセージで送ってもらえるようにしました。